### PR TITLE
Fixes for migration to killercoda

### DIFF
--- a/sming-host-emulator/step1.md
+++ b/sming-host-emulator/step1.md
@@ -40,7 +40,7 @@ We have a script that does that for us. To see its content execute the command b
 
 Now it is time to actually run the script.
 
-`$SMING_HOME/Arch/Host/Tools/setup-network-linux.sh ens3`{{execute}}
+`$SMING_HOME/Arch/Host/Tools/setup-network-linux.sh enp1s0`{{execute}}
 
 It will create a tap0 network interface for our applications and will allow our applications to access Internet.
 

--- a/sming-host-emulator/step1.md
+++ b/sming-host-emulator/step1.md
@@ -29,7 +29,12 @@ source Sming/Tools/export.sh
 ## Analyzing
 
 Valgrind is a tool that helps find memory issues within your application. In order to install it we need to execute the following command:
-`sudo apt-get install -y valgrind libc6-dbg:i386`{{execute}}
+
+```
+sudo dpkg --add-architecture i386
+sudo apt-get update
+sudo apt-get install -y valgrind libc6-dbg:i386
+```{{execute}}
 
 ## Network
 

--- a/sming-host-emulator/step2.md
+++ b/sming-host-emulator/step2.md
@@ -47,8 +47,8 @@ If you enter `cat`{{execute T3}} it will echo a file from the filing system to U
 Now let's compile one of the HttpServer samples coming with Sming.
 If we want to access our web server we need to expose expose port 80 from our application to be accessible via our web browser.
 ```
-sudo iptables -A FORWARD -i ens3 -o tap0 -p tcp --syn --dport 80 -m conntrack --ctstate NEW -j ACCEPT
-sudo iptables -t nat -A PREROUTING -i ens3 -p tcp --dport 80 -j DNAT --to-destination 192.168.13.10
+sudo iptables -A FORWARD -i enp1s0 -o tap0 -p tcp --syn --dport 80 -m conntrack --ctstate NEW -j ACCEPT
+sudo iptables -t nat -A PREROUTING -i enp1s0 -p tcp --dport 80 -j DNAT --to-destination 192.168.13.10
 ```{{execute}}
 
 The commands above are needed only for this tutorial and environment. Normally you should not expose a Sming Framework based web server to be accessible from Internet.
@@ -61,5 +61,5 @@ make -j3 flash run
 ```{{execute}}
 
 Take a look at the web server on this URL:
-https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/
+{{TRAFFIC_HOST1_80}}
 

--- a/sming-host-emulator/step3.md
+++ b/sming-host-emulator/step3.md
@@ -11,4 +11,5 @@ make valgrind
 ```{{execute}}
 
 Take a look at the web server on this URL:
-https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/
+{{TRAFFIC_HOST1_80}}
+


### PR DESCRIPTION
Network paths are different and valgrind install requires a tweak.

Note that valgrind is an old version and produces lots of missing syscall 407 errors. This corresponds to the `clock_nanosleep_time64` call, fixed in later versions. Not sure what the appropriate fix for this is.